### PR TITLE
Add deliveryservice to staging deployment script

### DIFF
--- a/.github/workflows/deploy-staging-selfhosted.yml
+++ b/.github/workflows/deploy-staging-selfhosted.yml
@@ -66,4 +66,4 @@ jobs:
     - name: Deploy application services
       shell: powershell
       run: |
-        docker compose -f deploy/docker-compose.staging.yml up -d orderservice inventoryservice
+        docker compose -f deploy/docker-compose.staging.yml up -d orderservice inventoryservice deliveryservice


### PR DESCRIPTION
Updated the deployment script to include the deliveryservice in the Docker Compose command, enabling it to be deployed alongside orderservice and inventoryservice.